### PR TITLE
Added inital reporter interface and models

### DIFF
--- a/src/html-reporter/AxeHTMLReport.cs
+++ b/src/html-reporter/AxeHTMLReport.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <summary>
+    /// Axe HTML Report
+    /// </summary>
+    public sealed class AxeHTMLReport
+    {
+        private readonly string m_htmlContent;
+
+        internal AxeHTMLReport(string htmlContent)
+        {
+            m_htmlContent = htmlContent;
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => m_htmlContent;
+
+        /// <summary>
+        /// Writes the HTML report to a file.
+        /// </summary>
+        /// <param name="filename">The outputted filename. Defaults to 'index.html'.</param>
+        /// <returns>This instance.</returns>
+        public AxeHTMLReport WriteToFile(string filename = null)
+        {
+            // TODO IsaacWalker - Write to file
+            return this;
+        }
+    }
+}

--- a/src/html-reporter/AxeHTMLReportOptions.cs
+++ b/src/html-reporter/AxeHTMLReportOptions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <summary>
+    /// Options for configuring the HTML report.
+    /// </summary>
+    public sealed class AxeHTMLReportOptions
+    {
+    }
+}

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <inheritdoc />
+    public sealed class AxeHTMLReporter : IAxeHTMLReporter
+    {
+        /// <summary>
+        /// Singleton instance.
+        /// </summary>
+        public static AxeHTMLReporter Instance { get; } = new AxeHTMLReporter();
+
+        internal AxeHTMLReporter()
+        {
+        }
+
+        /// <inheritdoc />
+        public AxeHTMLReport CreateReport(object results, AxeHTMLReportOptions options = null)
+        {
+            // TODO IsaacWalker - Implement Report Generation
+            return new AxeHTMLReport("<a> Hello World </a>");
+        }
+    }
+}

--- a/src/html-reporter/IAxeHTMLReporter.cs
+++ b/src/html-reporter/IAxeHTMLReporter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <summary>
+    /// Reporter for generting HTML Report of an axe-core run result.
+    /// </summary>
+    public interface IAxeHTMLReporter
+    {
+        /// <summary>
+        /// Creates a HTML Report for an axe-core run result.
+        /// </summary>
+        /// <param name="results">The axe-core results. TODO IsaacWalker - integrate with https://github.com/dequelabs/axe-core-nuget/blob/develop/packages/commons/src/AxeResult.cs</param>
+        /// <param name="options">HTML Report options.</param>
+        /// <returns>The HTML report object.</returns>
+        AxeHTMLReport CreateReport(object results, AxeHTMLReportOptions options = null);
+    }
+}


### PR DESCRIPTION
- Singleton creational pattern (DI will be used for testability and providing static content).
- Report options is for future extensibility.


Proposed usage:

```cs

IAxeHTMLReporter reporter = AxeHTMLReporter.Instance;

var report = reporter.CreateReport(results)
       .WriteToFile();

Console.WriteLine(report.ToString());

```

This will be the interface used primarily by the specific integrations (Playwright, Selenium).