### PR TITLE
Added initial Report templating.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,12 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
+	<PackageVersion Include="RazorEngineCore" Version="2022.8.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-	<PackageVersion Include="Moq" Version="4.18.2" />
-	<PackageVersion Include="NUnit" Version="3.13.3" />
-	<PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="Moq" Version="4.18.2" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 </Project>

--- a/src/html-reporter/AxeCore.HTMLReporter.csproj
+++ b/src/html-reporter/AxeCore.HTMLReporter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Authors>Isaac Walker</Authors>
@@ -9,5 +9,17 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/microsoft/html-reporter-for-axe-core-dotnet</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+	<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+	<PackageReference Include="RazorEngineCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+	 <EmbeddedResource Include="Content\Report.cshtml">
+	 </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -38,7 +38,8 @@ namespace AxeCore.HTMLReporter
         {
             string reportTemplateContent = GetContent("Content/Report.cshtml");
 
-            IRazorEngineCompiledTemplate template = m_razorEngine.Compile(reportTemplateContent, builder => {
+            IRazorEngineCompiledTemplate template = m_razorEngine.Compile(reportTemplateContent, builder =>
+            {
                 builder.AddAssemblyReference(typeof(DateTime));
             });
             string htmlReport = template.Run();

--- a/src/html-reporter/Content/Report.cshtml
+++ b/src/html-reporter/Content/Report.cshtml
@@ -1,0 +1,8 @@
+@{
+    // Copyright (c) Microsoft Corporation.
+    // Licensed under the MIT License.
+}
+
+@using System;
+
+<a>Hello World. It's @DateTime.Now.ToShortDateString()</a>


### PR DESCRIPTION
This PR adds the basic mechanism for creating the HTML Report.

It uses [RazorEngineCore](https://www.nuget.org/packages/RazorEngineCore) so that we can make use of Razor/cshtml when creating the report.

The cshml template is treated as an embedded resource so that it can be read in as a string and passed into the razor engine.