### PR TITLE
Added Report Layout

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+	<PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
 	<PackageVersion Include="RazorEngineCore" Version="2022.8.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
 	<PackageVersion Include="Deque.AxeCore.Commons" Version="4.4.0-alpha.c9651f2c2284967c64d2f28e460b5181d0af5c6d" />
   </ItemGroup>
 </Project>

--- a/src/html-reporter/AxeCore.HTMLReporter.csproj
+++ b/src/html-reporter/AxeCore.HTMLReporter.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
 	<PackageReference Include="RazorEngineCore" />

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -6,8 +6,11 @@ using Deque.AxeCore.Commons;
 using Microsoft.Extensions.FileProviders;
 using RazorEngineCore;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Net;
 
 namespace AxeCore.HTMLReporter
 {
@@ -47,11 +50,20 @@ namespace AxeCore.HTMLReporter
                 builder.AddAssemblyReference(typeof(CultureInfo));
                 builder.AddAssemblyReference(typeof(DateTime));
                 builder.AddAssemblyReference(typeof(AxeResult));
+                builder.AddAssemblyReference(typeof(Uri));
             });
 
             CultureInfo language = CultureInfo.CurrentCulture;
 
-            ReportViewModel viewModel = new ReportViewModel(language, results);
+            Uri testUri = results.Url != null ? new Uri(results.Url) : null;
+
+            string formattedTimestamp = results.Timestamp.HasValue
+                ? results.Timestamp.Value.DateTime.ToString("U", language.DateTimeFormat)
+                : null;
+
+            IDictionary<string, IList<RuleInfoModel>> ruleResultGroups = MapperHelper.MapAxeResultsToResultsGroup(results);
+
+            ReportViewModel viewModel = new ReportViewModel(language, testUri, formattedTimestamp, ruleResultGroups);
             string htmlReport = template.Run(viewModel);
 
             return new AxeHTMLReport(htmlReport);

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -46,6 +46,7 @@ namespace AxeCore.HTMLReporter
 
             IRazorEngineCompiledTemplate template = m_razorEngine.Compile(reportTemplateContent, builder =>
             {
+                builder.AddAssemblyReference(typeof(Microsoft.CSharp.RuntimeBinder.RuntimeBinderException));
                 builder.AddAssemblyReference(typeof(ReportViewModel));
                 builder.AddAssemblyReference(typeof(CultureInfo));
                 builder.AddAssemblyReference(typeof(DateTime));

--- a/src/html-reporter/Content/Report.cshtml
+++ b/src/html-reporter/Content/Report.cshtml
@@ -1,32 +1,111 @@
 @{
     // Copyright (c) Microsoft Corporation.
-    // Licensed under the MIT License.
+            // Licensed under the MIT License.
 }
 
 @using System;
+@using AxeCore.HTMLReporter;
 @using AxeCore.HTMLReporter.Content;
 
 @{
     var viewModel = Model as AxeCore.HTMLReporter.Models.ReportViewModel;
     var languageDir = viewModel.Language.TextInfo.IsRightToLeft ? "rtl" : "ltr";
 
-    var results = viewModel.Results;
+    var resultGroups = viewModel.RuleResultGroups;
+    var testUrl = viewModel.TestUri;
+    var timestamp = viewModel.FormattedTimestamp;
+    var violationCount = resultGroups[ReportContants.ViolationsKey].Count;
+    var passCount = resultGroups[ReportContants.PassesKey].Count;
+    var incompleteCount = resultGroups[ReportContants.IncompleteKey].Count;
+    var inapplicableCount = resultGroups[ReportContants.Inapplicable].Count;
 }
 
+<!DOCTYPE html>
 <html lang="@viewModel.Language.TwoLetterISOLanguageName" dir="@languageDir">
-    <head>
-        <title>@Strings.Title</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<head>
+    <title>@Strings.Title</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <style>
-            h1 {
-                color: blue
-            }
-        </style>
-    </head>
-    <body>
-        <h1>Hello world</h1>
-        <a>@results.Url</a>
-    </body>
+    <style>
+
+    </style>
+</head>
+<body>
+    <h1>@Strings.Title</h1>
+    <br />
+    <table>
+        <tr>
+            <td>@Strings.TestUrlRowName</td>
+            <td>@testUrl</td>
+        </tr>
+        <tr>
+            <td>@Strings.TimestampRowName</td>
+            <td>@timestamp</td>
+        </tr>
+        <tr>
+            <td>@Strings.ViolationsRowName</td>
+            <td><a href="#@ReportContants.ViolationsKey">@violationCount</a></td>
+        </tr>
+        <tr>
+            <td>@Strings.PassesRowName</td>
+            <td><a href="#@ReportContants.PassesKey">@passCount</a></td>
+        </tr>
+        <tr>
+            <td>@Strings.IncompleteRowName</td>
+            <td><a href="#@ReportContants.IncompleteKey">@incompleteCount</a></td>
+        </tr>
+        <tr>
+            <td>@Strings.InapplicableRowName</td>
+            <td><a href="#@ReportContants.Inapplicable">@inapplicableCount</a></td>
+        </tr>
+    </table>
+    <br />
+    @{
+        foreach (var ruleGroup in resultGroups)
+        {
+            <section id="@ruleGroup.Key">
+                @{
+                    foreach (var rule in ruleGroup.Value)
+                    {
+                        <hr />
+                        <section id="@rule.Id">
+                            <h2>@string.Format(Strings.RuleHeaderTemplate, @rule.DisplayName, @rule.Description)</h2>
+                            <table>
+                                <tr>
+                                    <td>@Strings.ImpactRowName</td>
+                                    <td>@rule.Impact</td>
+                                </tr>
+                                <tr>
+                                    <td>@Strings.HelpUrlRowName</td>
+                                    <td><a href="@rule.HelpUrl">@rule.HelpUrl</a></td>
+                                </tr>
+                                <tr>
+                                    <td>@Strings.TagsRowName</td>
+                                    <td>@string.Join(", ", rule.Tags)</td>
+                                </tr>
+                            </table>
+                            <br />
+                            @{
+                                foreach (var ruleNode in rule.RuleNodes)
+                                {
+                                    <div>
+                                        <dl>
+                                            <dt>@Strings.HTMLLabel</dt>
+                                            <dd>@ruleNode.Html</dd>
+                                        </dl>
+                                        <dl>
+                                            <dt>@Strings.SelectorsLabel</dt>
+                                            <dd>@ruleNode.Selector</dd>
+                                        </dl>
+                                    </div>
+                                }
+                            }
+                        </section>
+                    }
+                }
+            </section>
+        }
+    }
+</body>
 </html>

--- a/src/html-reporter/Content/Report.cshtml
+++ b/src/html-reporter/Content/Report.cshtml
@@ -70,7 +70,7 @@
                     {
                         <hr />
                         <section id="@rule.Id">
-                            <h2>@string.Format(Strings.RuleHeaderTemplate, @rule.DisplayName, @rule.Description)</h2>
+                            <h2>@string.Format(Strings.RuleHeaderTemplate, @rule.DisplayName, @rule.HelpUrl)</h2>
                             <table>
                                 <tr>
                                     <td>@Strings.ImpactRowName</td>

--- a/src/html-reporter/Content/Strings.Designer.cs
+++ b/src/html-reporter/Content/Strings.Designer.cs
@@ -61,11 +61,119 @@ namespace AxeCore.HTMLReporter.Content {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Help Url.
+        /// </summary>
+        public static string HelpUrlRowName {
+            get {
+                return ResourceManager.GetString("HelpUrlRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HTML.
+        /// </summary>
+        public static string HTMLLabel {
+            get {
+                return ResourceManager.GetString("HTMLLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Impact.
+        /// </summary>
+        public static string ImpactRowName {
+            get {
+                return ResourceManager.GetString("ImpactRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inapplicable.
+        /// </summary>
+        public static string InapplicableRowName {
+            get {
+                return ResourceManager.GetString("InapplicableRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Incomplete.
+        /// </summary>
+        public static string IncompleteRowName {
+            get {
+                return ResourceManager.GetString("IncompleteRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Passes.
+        /// </summary>
+        public static string PassesRowName {
+            get {
+                return ResourceManager.GetString("PassesRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} - {1}.
+        /// </summary>
+        public static string RuleHeaderTemplate {
+            get {
+                return ResourceManager.GetString("RuleHeaderTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selector(s).
+        /// </summary>
+        public static string SelectorsLabel {
+            get {
+                return ResourceManager.GetString("SelectorsLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tags.
+        /// </summary>
+        public static string TagsRowName {
+            get {
+                return ResourceManager.GetString("TagsRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test URL.
+        /// </summary>
+        public static string TestUrlRowName {
+            get {
+                return ResourceManager.GetString("TestUrlRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Timestamp.
+        /// </summary>
+        public static string TimestampRowName {
+            get {
+                return ResourceManager.GetString("TimestampRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Accessibility Report.
         /// </summary>
         public static string Title {
             get {
                 return ResourceManager.GetString("Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Violations.
+        /// </summary>
+        public static string ViolationsRowName {
+            get {
+                return ResourceManager.GetString("ViolationsRowName", resourceCulture);
             }
         }
     }

--- a/src/html-reporter/Content/Strings.resx
+++ b/src/html-reporter/Content/Strings.resx
@@ -117,7 +117,43 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="HelpUrlRowName" xml:space="preserve">
+    <value>Help Url</value>
+  </data>
+  <data name="HTMLLabel" xml:space="preserve">
+    <value>HTML</value>
+  </data>
+  <data name="ImpactRowName" xml:space="preserve">
+    <value>Impact</value>
+  </data>
+  <data name="InapplicableRowName" xml:space="preserve">
+    <value>Inapplicable</value>
+  </data>
+  <data name="IncompleteRowName" xml:space="preserve">
+    <value>Incomplete</value>
+  </data>
+  <data name="PassesRowName" xml:space="preserve">
+    <value>Passes</value>
+  </data>
+  <data name="RuleHeaderTemplate" xml:space="preserve">
+    <value>{0} - {1}</value>
+  </data>
+  <data name="SelectorsLabel" xml:space="preserve">
+    <value>Selector(s)</value>
+  </data>
+  <data name="TagsRowName" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="TestUrlRowName" xml:space="preserve">
+    <value>Test URL</value>
+  </data>
+  <data name="TimestampRowName" xml:space="preserve">
+    <value>Timestamp</value>
+  </data>
   <data name="Title" xml:space="preserve">
     <value>Accessibility Report</value>
+  </data>
+  <data name="ViolationsRowName" xml:space="preserve">
+    <value>Violations</value>
   </data>
 </root>

--- a/src/html-reporter/MapperHelper.cs
+++ b/src/html-reporter/MapperHelper.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+using AxeCore.HTMLReporter.Models;
+using Deque.AxeCore.Commons;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace AxeCore.HTMLReporter
+{
+    internal static class MapperHelper
+    {
+        internal static IDictionary<string, IList<RuleInfoModel>> MapAxeResultsToResultsGroup(AxeResult results)
+        {
+            return new Dictionary<string, IList<RuleInfoModel>>()
+            {
+                { ReportContants.ViolationsKey, MapAxeResultToRuleInfo(results.Violations ?? Array.Empty<AxeResultItem>()) },
+                { ReportContants.PassesKey, MapAxeResultToRuleInfo(results.Passes ?? Array.Empty<AxeResultItem>()) },
+                { ReportContants.IncompleteKey, MapAxeResultToRuleInfo(results.Incomplete ?? Array.Empty<AxeResultItem>()) },
+                { ReportContants.Inapplicable, MapAxeResultToRuleInfo(results.Inapplicable ?? Array.Empty < AxeResultItem >()) },
+            };
+        }
+
+        private static List<RuleInfoModel> MapAxeResultToRuleInfo(AxeResultItem[] resultItems)
+        {
+            return resultItems.Select(axeResultItem =>
+            {
+                string id = WebUtility.HtmlEncode(axeResultItem.Id);
+                string displayName = WebUtility.HtmlEncode(axeResultItem.Id?.Replace('-', ' '));
+                string description = WebUtility.HtmlEncode(axeResultItem.Description);
+                string impact = WebUtility.HtmlEncode(axeResultItem.Impact);
+                Uri helpUrl = new Uri(axeResultItem.HelpUrl);
+                IList<string> tags = axeResultItem.Tags ?? Array.Empty<string>();
+
+                IList<RuleNodeInfoModel> nodes = axeResultItem.Nodes?.Select(node =>
+                {
+                    string html = WebUtility.HtmlEncode(node.Html ?? string.Empty);
+                    string selector = WebUtility.HtmlEncode(node.Target?.ToString());
+
+                    return new RuleNodeInfoModel(html, selector);
+                }).ToList() ?? Array.Empty<RuleNodeInfoModel>().ToList();
+
+                return new RuleInfoModel(id, displayName, description, impact, helpUrl, tags, nodes);
+            }).ToList();
+        }
+    }
+}

--- a/src/html-reporter/Models/ReportViewModel.cs
+++ b/src/html-reporter/Models/ReportViewModel.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Deque.AxeCore.Commons;
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace AxeCore.HTMLReporter.Models
@@ -17,17 +18,29 @@ namespace AxeCore.HTMLReporter.Models
         public CultureInfo Language { get; }
 
         /// <summary>
+        /// Test URI
+        /// </summary>
+        public Uri TestUri { get; }
+
+        /// <summary>
+        /// Formatted Timestamp
+        /// </summary>
+        public string FormattedTimestamp { get; }
+
+        /// <summary>
         /// Axe Results
         /// </summary>
-        public AxeResult Results { get; }
+        public IDictionary<string, IList<RuleInfoModel>> RuleResultGroups { get; }
 
         /// <summary>
         /// Constructor
         /// </summary>
-        internal ReportViewModel(CultureInfo language, AxeResult results)
+        internal ReportViewModel(CultureInfo language, Uri testUri, string formattedTimestamp, IDictionary<string, IList<RuleInfoModel>> ruleResultGroups)
         {
             Language = language;
-            Results = results;
+            TestUri = testUri;
+            FormattedTimestamp = formattedTimestamp;
+            RuleResultGroups = ruleResultGroups;
         }
     }
 }

--- a/src/html-reporter/Models/RuleInfoModel.cs
+++ b/src/html-reporter/Models/RuleInfoModel.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace AxeCore.HTMLReporter.Models
+{
+    /// <summary>
+    /// Represents all the information for a rule on the report.
+    /// </summary>
+    public sealed class RuleInfoModel
+    {
+        /// <summary>
+        /// Id
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Display Name
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Description
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
+        /// Impact
+        /// </summary>
+        public string Impact { get; }
+
+        /// <summary>
+        /// Help Url
+        /// </summary>
+        public Uri HelpUrl { get; }
+
+        /// <summary>
+        /// Tags
+        /// </summary>
+        public IList<string> Tags { get; }
+
+        /// <summary>
+        /// Rule Nodes
+        /// </summary>
+        public IList<RuleNodeInfoModel> RuleNodes { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public RuleInfoModel(
+            string id,
+            string displayName,
+            string description,
+            string impact,
+            Uri helpUrl,
+            IList<string> tags,
+            IList<RuleNodeInfoModel> ruleNodes
+            )
+        {
+            Id = id;
+            DisplayName = displayName;
+            Description = description;
+            Impact = impact;
+            HelpUrl = helpUrl;
+            Tags = tags;
+            RuleNodes = ruleNodes;
+        }
+    }
+}

--- a/src/html-reporter/Models/RuleNodeInfoModel.cs
+++ b/src/html-reporter/Models/RuleNodeInfoModel.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter.Models
+{
+    /// <summary>
+    /// Represents a particular instance where a rule was calculated.
+    /// </summary>
+    public sealed class RuleNodeInfoModel
+    {
+        /// <summary>
+        /// The sample markup.
+        /// </summary>
+        public string Html { get; set; }
+
+        /// <summary>
+        /// Selector
+        /// </summary>
+        public string Selector { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public RuleNodeInfoModel(string html, string selector) {
+            Html = html;
+            Selector = selector;
+        }
+    }
+}

--- a/src/html-reporter/Models/RuleNodeInfoModel.cs
+++ b/src/html-reporter/Models/RuleNodeInfoModel.cs
@@ -21,7 +21,8 @@ namespace AxeCore.HTMLReporter.Models
         /// <summary>
         /// Constructor
         /// </summary>
-        public RuleNodeInfoModel(string html, string selector) {
+        public RuleNodeInfoModel(string html, string selector)
+        {
             Html = html;
             Selector = selector;
         }

--- a/src/html-reporter/ReportContants.cs
+++ b/src/html-reporter/ReportContants.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <summary>
+    /// Constants
+    /// </summary>
+    public static class ReportContants
+    {
+        public const string ViolationsKey = "violations";
+
+        public const string PassesKey = "passes";
+
+        public const string IncompleteKey = "incomplete";
+
+        public const string Inapplicable = "inapplicable";
+    }
+}

--- a/tests/html-reporter/AxeHTMLReporterTests.cs
+++ b/tests/html-reporter/AxeHTMLReporterTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace AxeCore.HTMLReporter.Tests
+{
+    [TestFixture]
+    public sealed class AxeHTMLReporterTests
+    {
+        [Test]
+        public void Test()
+        {
+            AxeHTMLReporter reporter = GetInstance();
+
+            AxeHTMLReport report = reporter.CreateReport(TestData.CreateDefaultResult());
+
+            Assert.IsNotNull(report);
+            Assert.IsNotEmpty(report.ToString());
+        }
+
+        private AxeHTMLReporter GetInstance()
+        {
+            return AxeHTMLReporter.Instance;
+        }
+    }
+}

--- a/tests/html-reporter/TestData.cs
+++ b/tests/html-reporter/TestData.cs
@@ -1,17 +1,15 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-using Deque.AxeCore.Commons;
+﻿using Deque.AxeCore.Commons;
 using Newtonsoft.Json.Linq;
+using System;
 
-namespace AxeCore.HTMLReporter.DevServer
+namespace AxeCore.HTMLReporter.Tests
 {
-    public sealed class MockDataFactory
+    internal static class TestData
     {
-        public static AxeResult CreateMockResultData()
+        internal static AxeResult CreateDefaultResult()
         {
             AxeResultItem[] violations = new AxeResultItem[]
-            {
+           {
                 new AxeResultItem()
                 {
                     Id = "html-has-lang",
@@ -31,7 +29,7 @@ namespace AxeCore.HTMLReporter.DevServer
                     Tags = new string[] { "cat.forms", "wcag2a", "wcag412", "section508", "section508.22.n", "ACT" },
                     Impact = "Serious"
                 }
-            };
+           };
 
             AxeResultItem[] passes = new AxeResultItem[]
             {
@@ -92,7 +90,7 @@ namespace AxeCore.HTMLReporter.DevServer
                 incomplete
             });
 
-            AxeResult mockResult = new(resultJson);
+            AxeResult mockResult = new AxeResult(resultJson);
 
             return mockResult;
         }


### PR DESCRIPTION

Added the basic report layout without styling.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/36536997/216850026-4fecb632-31f7-4c4d-8a3d-67ce1275761d.png">


When styling is added, and functionality to embed images, it should look as such:
![image](https://user-images.githubusercontent.com/36536997/216850048-b239701f-1f3f-4d34-9420-341d69231e10.png)

