### PR TITLE
Added report generation in dev server

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
 	<PackageVersion Include="Handlebars.Net" Version="2.1.2" />
+	<PackageVersion Include="Microsoft.Playwright" Version="1.20.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
 	<PackageVersion Include="Deque.AxeCore.Commons" Version="4.4.0-alpha.c9651f2c2284967c64d2f28e460b5181d0af5c6d" />
+    <PackageVersion Include="Deque.AxeCore.Playwright" Version="4.4.0-alpha.c9651f2c2284967c64d2f28e460b5181d0af5c6d" />
   </ItemGroup>
 </Project>

--- a/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
+++ b/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
 	<Target Name="InstallPlaywright" AfterTargets="AfterBuild">
-		<Exec Command="pwsh .\$(OutDir)playwright.ps1 install"></Exec>
+		<Exec Command="pwsh .\$(OutDir)playwright.ps1 install" Condition="$([MSBuild]::IsOSPlatform('Windows'))"></Exec>
+		<Exec Command="pwsh $(OutDir)playwright.ps1 install" Condition="$([MSBuild]::IsOSPlatform('Linux'))"></Exec>
 	</Target>
 </Project>

--- a/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
+++ b/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
@@ -5,7 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\html-reporter\AxeCore.HTMLReporter.csproj" />
+	<PackageReference Include="Microsoft.Playwright" />
+	<PackageReference Include="Deque.AxeCore.Commons" />
+	<PackageReference Include="Deque.AxeCore.Playwright" />
   </ItemGroup>
+
+	<Target Name="InstallPlaywright" AfterTargets="AfterBuild">
+		<Exec Command="powershell .\$(OutDir)playwright.ps1 install"></Exec>
+	</Target>
 </Project>

--- a/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
+++ b/src/dev-server/AxeCore.HTMLReporter.DevServer.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
 	<Target Name="InstallPlaywright" AfterTargets="AfterBuild">
-		<Exec Command="powershell .\$(OutDir)playwright.ps1 install"></Exec>
+		<Exec Command="pwsh .\$(OutDir)playwright.ps1 install"></Exec>
 	</Target>
 </Project>

--- a/src/dev-server/Program.cs
+++ b/src/dev-server/Program.cs
@@ -26,7 +26,7 @@ app.MapGet("/", async (context) =>
         await page.GotoAsync(testUrl.ToString());
 
         axeResults = await page.RunAxe();
-    } 
+    }
     else
     {
         axeResults = MockDataFactory.CreateMockResultData();

--- a/src/dev-server/Program.cs
+++ b/src/dev-server/Program.cs
@@ -4,18 +4,36 @@
 using AxeCore.HTMLReporter;
 using AxeCore.HTMLReporter.DevServer;
 using Deque.AxeCore.Commons;
+using Deque.AxeCore.Playwright;
+using Microsoft.Playwright;
 
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
 IAxeHTMLReporter reporter = AxeHTMLReporter.Instance;
 
-app.MapGet("/", (context) =>
+app.MapGet("/", async (context) =>
 {
-    AxeResult mockResult = MockDataFactory.CreateMockResultData();
+    AxeResult axeResults;
 
-    AxeHTMLReport report = reporter.CreateReport(mockResult);
-    return context.Response.WriteAsync(report.ToString());
+    if (context.Request.Query.ContainsKey("testUrl") &&
+        Uri.TryCreate(context.Request.Query["testUrl"], UriKind.Absolute, out Uri? testUrl))
+    {
+        using var playwright = await Playwright.CreateAsync();
+
+        await using var browser = await playwright.Chromium.LaunchAsync();
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(testUrl.ToString());
+
+        axeResults = await page.RunAxe();
+    } 
+    else
+    {
+        axeResults = MockDataFactory.CreateMockResultData();
+    }
+
+    AxeHTMLReport report = reporter.CreateReport(axeResults);
+    await context.Response.WriteAsync(report.ToString());
 });
 
 app.Run();

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -107,9 +107,9 @@ namespace AxeCore.HTMLReporter
                     RuleNodes = ruleResult.Nodes?.Select(node => new RuleNodeModel()
                     {
                         HTMLLabel = Strings.HTMLLabel,
-                        HTML = WebUtility.HtmlEncode(node.Html),
+                        HTML = node.Html,
                         SelectorLabel = Strings.SelectorsLabel,
-                        Selector = WebUtility.HtmlEncode(node.Target.ToString()),
+                        Selector = node.Target.ToString(),
                     }).ToArray() ?? Array.Empty<RuleNodeModel>()
                 }).ToArray(),
             };

--- a/src/html-reporter/Templates/HtmlTemplates.cs
+++ b/src/html-reporter/Templates/HtmlTemplates.cs
@@ -28,19 +28,19 @@ namespace AxeCore.HTMLReporter.Templates
                     </tr>
                     <tr>
                         <td>{{ViolationsRowName}}</td>
-                        <td><a href=""{{ViolationsKey}}"">{{ViolationsCount}}</a></td>
+                        <td><a href=""#{{ViolationsKey}}"">{{ViolationsCount}}</a></td>
                     </tr>
                     <tr>
                         <td>{{PassesRowName}}</td>
-                        <td><a href=""{{PassesKey}}"">{{PassesCount}}</a></td>
+                        <td><a href=""#{{PassesKey}}"">{{PassesCount}}</a></td>
                     </tr>
                     <tr>
                         <td>{{IncompleteRowName}}</td>
-                        <td><a href=""{{IncompleteKey}}"">{{IncompleteCount}}</a></td>
+                        <td><a href=""#{{IncompleteKey}}"">{{IncompleteCount}}</a></td>
                     </tr>
                     <tr>
                         <td>{{InapplicableRowName}}</td>
-                        <td><a href=""{{InapplicableKey}}"">{{InapplicableCount}}</a></td>
+                        <td><a href=""#{{InapplicableKey}}"">{{InapplicableCount}}</a></td>
                     </tr>
                 </table>
                 <br />


### PR DESCRIPTION
Added the ability to parametrically add a url in the dev server so any site can be tested with the dev server via a 'testUrl' query string parameter:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/36536997/217374994-34c47b25-b4af-4702-b976-6e84dcccf450.png">

Also addressed some double-encoding issues which were found.