### PR TITLE
Updated styling and node count calculation

### DIFF
--- a/src/dev-server/Program.cs
+++ b/src/dev-server/Program.cs
@@ -32,7 +32,19 @@ app.MapGet("/", async (context) =>
         axeResults = MockDataFactory.CreateMockResultData();
     }
 
-    AxeHTMLReport report = reporter.CreateReport(axeResults);
+    AxeReportRuleTypes[] reportRuleTypes = (context.Request.Query.ContainsKey(nameof(AxeHTMLReportOptions.ReportRuleTypes))
+        ? context.Request.Query[nameof(AxeHTMLReportOptions.ReportRuleTypes)]
+            .Select(queryItem => Enum.Parse<AxeReportRuleTypes>(queryItem))
+            .ToArray()
+        : new AxeReportRuleTypes[] { AxeReportRuleTypes.Violations });
+
+    AxeHTMLReportOptions options = new()
+    {
+        ReportRuleTypes = reportRuleTypes
+            .Aggregate(reportRuleTypes.First(), (last, next) => last | next)
+    };
+
+    AxeHTMLReport report = reporter.CreateReport(axeResults, options);
     await context.Response.WriteAsync(report.ToString());
 });
 

--- a/src/html-reporter/AxeHTMLReport.cs
+++ b/src/html-reporter/AxeHTMLReport.cs
@@ -33,7 +33,7 @@ namespace AxeCore.HTMLReporter
 
             string directory = Path.GetDirectoryName(reportFilename);
 
-            if(!string.IsNullOrWhiteSpace(directory)) 
+            if (!string.IsNullOrWhiteSpace(directory))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(reportFilename));
             }

--- a/src/html-reporter/AxeHTMLReport.cs
+++ b/src/html-reporter/AxeHTMLReport.cs
@@ -31,7 +31,13 @@ namespace AxeCore.HTMLReporter
         {
             string reportFilename = filename ?? DefaultFilename;
 
-            Directory.CreateDirectory(Path.GetDirectoryName(reportFilename));
+            string directory = Path.GetDirectoryName(reportFilename);
+
+            if(!string.IsNullOrWhiteSpace(directory)) 
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(reportFilename));
+            }
+
             File.WriteAllText(reportFilename, m_htmlContent);
 
             return this;

--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -65,6 +65,11 @@ namespace AxeCore.HTMLReporter
                 options)
                 .ToArray();
 
+            int violationCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Violations);
+            int passesCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Passes);
+            int incompleteCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Incomplete);
+            int inapplicableCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Inapplicable);
+
             return new ReportViewModel()
             {
                 LanguageCode = language.TwoLetterISOLanguageName,
@@ -76,16 +81,16 @@ namespace AxeCore.HTMLReporter
                 Timestamp = formattedTimestamp,
                 ViolationsRowName = Strings.ViolationsRowName,
                 ViolationsKey = ReportContants.ViolationsKey,
-                ViolationsCount = results.Violations.Length,
+                ViolationsCount = violationCount,
                 PassesRowName = Strings.PassesRowName,
                 PassesKey = ReportContants.PassesKey,
-                PassesCount = results.Passes.Length,
+                PassesCount = passesCount,
                 IncompleteRowName = Strings.IncompleteRowName,
                 IncompleteKey = ReportContants.IncompleteKey,
-                IncompleteCount = results.Incomplete.Length,
+                IncompleteCount = incompleteCount,
                 InapplicableRowName = Strings.InapplicableRowName,
                 InapplicableKey = ReportContants.InapplicableKey,
-                InapplicableCount = results.Inapplicable.Length,
+                InapplicableCount = inapplicableCount,
                 RuleGroups = ruleGroups
             };
         }

--- a/src/html-reporter/Content/Strings.Designer.cs
+++ b/src/html-reporter/Content/Strings.Designer.cs
@@ -90,9 +90,27 @@ namespace AxeCore.HTMLReporter.Content {
         /// <summary>
         ///   Looks up a localized string similar to Inapplicable.
         /// </summary>
+        public static string InapplicableOutcome {
+            get {
+                return ResourceManager.GetString("InapplicableOutcome", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inapplicable.
+        /// </summary>
         public static string InapplicableRowName {
             get {
                 return ResourceManager.GetString("InapplicableRowName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Incomplete.
+        /// </summary>
+        public static string IncompleteOutcome {
+            get {
+                return ResourceManager.GetString("IncompleteOutcome", resourceCulture);
             }
         }
         
@@ -115,11 +133,29 @@ namespace AxeCore.HTMLReporter.Content {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Passed.
+        /// </summary>
+        public static string PassOutcome {
+            get {
+                return ResourceManager.GetString("PassOutcome", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} - {1}.
         /// </summary>
         public static string RuleHeaderTemplate {
             get {
                 return ResourceManager.GetString("RuleHeaderTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Outcome.
+        /// </summary>
+        public static string RuleOutcomeRowName {
+            get {
+                return ResourceManager.GetString("RuleOutcomeRowName", resourceCulture);
             }
         }
         
@@ -165,6 +201,15 @@ namespace AxeCore.HTMLReporter.Content {
         public static string Title {
             get {
                 return ResourceManager.GetString("Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Violation.
+        /// </summary>
+        public static string ViolationOutcome {
+            get {
+                return ResourceManager.GetString("ViolationOutcome", resourceCulture);
             }
         }
         

--- a/src/html-reporter/Content/Strings.resx
+++ b/src/html-reporter/Content/Strings.resx
@@ -126,8 +126,14 @@
   <data name="ImpactRowName" xml:space="preserve">
     <value>Impact</value>
   </data>
+  <data name="InapplicableOutcome" xml:space="preserve">
+    <value>Inapplicable</value>
+  </data>
   <data name="InapplicableRowName" xml:space="preserve">
     <value>Inapplicable</value>
+  </data>
+  <data name="IncompleteOutcome" xml:space="preserve">
+    <value>Incomplete</value>
   </data>
   <data name="IncompleteRowName" xml:space="preserve">
     <value>Incomplete</value>
@@ -135,8 +141,14 @@
   <data name="PassesRowName" xml:space="preserve">
     <value>Passes</value>
   </data>
+  <data name="PassOutcome" xml:space="preserve">
+    <value>Passed</value>
+  </data>
   <data name="RuleHeaderTemplate" xml:space="preserve">
     <value>{0} - {1}</value>
+  </data>
+  <data name="RuleOutcomeRowName" xml:space="preserve">
+    <value>Outcome</value>
   </data>
   <data name="SelectorsLabel" xml:space="preserve">
     <value>Selector(s)</value>
@@ -152,6 +164,9 @@
   </data>
   <data name="Title" xml:space="preserve">
     <value>Accessibility Report</value>
+  </data>
+  <data name="ViolationOutcome" xml:space="preserve">
+    <value>Violation</value>
   </data>
   <data name="ViolationsRowName" xml:space="preserve">
     <value>Violations</value>

--- a/src/html-reporter/Models/RuleModel.cs
+++ b/src/html-reporter/Models/RuleModel.cs
@@ -19,6 +19,21 @@ namespace AxeCore.HTMLReporter.Models
         public string RuleTitle { get; set; }
 
         /// <summary>
+        /// Rule Group Id
+        /// </summary>
+        public string RuleGroupId { get; set; }
+
+        /// <summary>
+        /// Rule Outcome Row Name
+        /// </summary>
+        public string RuleOutcomeRowName { get; set; }
+
+        /// <summary>
+        /// Rule Outcome
+        /// </summary>
+        public string RuleOutcome { get; set; }
+
+        /// <summary>
         /// Impact Row Name
         /// </summary>
         public string ImpactRowName { get; set; }

--- a/src/html-reporter/RuleGroupUtils.cs
+++ b/src/html-reporter/RuleGroupUtils.cs
@@ -49,6 +49,14 @@ namespace AxeCore.HTMLReporter
             yield break;
         }
 
+        /// <summary>
+        /// Gets the number of occurences of a rule (i.e. nodes).
+        /// </summary>
+        public static int GetRuleGroupNodeCount(AxeResultItem[] results)
+        {
+            return results.Sum(result => result.Nodes?.Length ?? 0);
+        }
+
         private static RuleGroupModel CreateRuleGroup(string ruleGroupId, AxeResultItem[] itemResults, CultureInfo locale)
         {
             return new RuleGroupModel()
@@ -60,6 +68,9 @@ namespace AxeCore.HTMLReporter
                     RuleTitle = string.Format(
                         Strings.RuleHeaderTemplate,
                         locale.TextInfo.ToTitleCase(ruleResult.Id.Replace('-', ' ')), ruleResult.Help),
+                    RuleGroupId = ruleGroupId,
+                    RuleOutcomeRowName = Strings.RuleOutcomeRowName,
+                    RuleOutcome = GetRuleOutcome(ruleGroupId),
                     ImpactRowName = Strings.ImpactRowName,
                     Impact = ruleResult.Impact,
                     HelpUrlRowName = Strings.HelpUrlRowName,
@@ -75,6 +86,21 @@ namespace AxeCore.HTMLReporter
                     }).ToArray() ?? Array.Empty<RuleNodeModel>()
                 }).ToArray(),
             };
+        }
+
+        private static string GetRuleOutcome(string ruleGroupId)
+        {
+            switch (ruleGroupId)
+            {
+                case ReportContants.ViolationsKey:
+                    return Strings.ViolationOutcome;
+                case ReportContants.IncompleteKey:
+                    return Strings.IncompleteOutcome;
+                case ReportContants.InapplicableKey:
+                    return Strings.InapplicableOutcome;
+                default:
+                    return Strings.PassOutcome;
+            }
         }
     }
 }

--- a/src/html-reporter/Templates/HtmlTemplates.cs
+++ b/src/html-reporter/Templates/HtmlTemplates.cs
@@ -15,6 +15,8 @@ namespace AxeCore.HTMLReporter.Templates
                     body {
                         font-family: 'Segoe ui';
                         margin: 20px;
+                        display: flex;
+                        flex-direction: column; 
                     }
 
                     h1 {
@@ -30,6 +32,10 @@ namespace AxeCore.HTMLReporter.Templates
                         text-align: left;
                         border-bottom-style: solid;
                         border-bottom-width: 2px;
+                    }
+
+                    .summaryRegion {
+                        width: 40%;
                     }
 
                     .table-row {
@@ -54,48 +60,92 @@ namespace AxeCore.HTMLReporter.Templates
                         padding: 20px;
                     }
 
-                    section.violation {
-                        color: #CC6D6D;
+                    section.rule {
+                        flex-direction: column;
                     }
 
-                    hr.violation {
-                        border-color: #CC6D6D;
+                    table.rule {
+                        width: 40%;
                     }
 
-                    table.violation {
-                        color: #CC6D6D;
+                    section.violations {
+                        color: #ad5c5c;
+                    }
+
+                    hr.violations {
+                        border-color: #ad5c5c;
+                    }
+
+                    table.violations {
+                        color: #ad5c5c;
+                    }
+
+                    section.passes {
+                        color: #208720;
+                    }
+
+                    hr.passes {
+                        border-color: #208720;
+                    }
+
+                    table.passes {
+                        color: #208720;
+                    }
+
+                    section.incomplete {
+                        color: #9b6d24;
+                    }
+
+                    hr.incomplete {
+                        border-color: #9b6d24;
+                    }
+
+                    table.incomplete {
+                        color: #9b6d24;
+                    }
+
+                    section.inapplicable {
+                        color: #737373;
+                    }
+
+                    hr.inapplicable {
+                        border-color: #737373;
+                    }
+
+                    table.inapplicable {
+                        color: #737373;
                     }
                 </style>
             </head>
             <body>
                 <h1>{{Title}}</h1>
                 <br />
-                <table>
-                    <tr>
-                        <td class=""table-row"">{{TestUrlRowName}}</td>
-                        <td class=""table-entry"">{{TestUrl}}</td>
-                    </tr>
-                    <tr>
-                        <td class=""table-row"">{{TimestampRowName}}</td>
-                        <td class=""table-entry"">{{Timestamp}}</td>
-                    </tr>
-                    <tr>
-                        <td class=""table-row"">{{ViolationsRowName}}</td>
-                        <td class=""table-entry""><a href=""#{{ViolationsKey}}"">{{ViolationsCount}}</a></td>
-                    </tr>
-                    <tr>
-                        <td class=""table-row"">{{PassesRowName}}</td>
-                        <td class=""table-entry""><a href=""#{{PassesKey}}"">{{PassesCount}}</a></td>
-                    </tr>
-                    <tr>
-                        <td class=""table-row"">{{IncompleteRowName}}</td>
-                        <td class=""table-entry""><a href=""#{{IncompleteKey}}"">{{IncompleteCount}}</a></td>
-                    </tr>
-                    <tr>
-                        <td class=""table-row"">{{InapplicableRowName}}</td>
-                        <td class=""table-entry""><a href=""#{{InapplicableKey}}"">{{InapplicableCount}}</a></td>
-                    </tr>
-                </table>
+                    <table class=""summaryRegion"">
+                        <tr>
+                            <td class=""table-row"">{{TestUrlRowName}}</td>
+                            <td class=""table-entry"">{{TestUrl}}</td>
+                        </tr>
+                        <tr>
+                            <td class=""table-row"">{{TimestampRowName}}</td>
+                            <td class=""table-entry"">{{Timestamp}}</td>
+                        </tr>
+                        <tr>
+                            <td class=""table-row"">{{ViolationsRowName}}</td>
+                            <td class=""table-entry""><a href=""#{{ViolationsKey}}"">{{ViolationsCount}}</a></td>
+                        </tr>
+                        <tr>
+                            <td class=""table-row"">{{PassesRowName}}</td>
+                            <td class=""table-entry""><a href=""#{{PassesKey}}"">{{PassesCount}}</a></td>
+                        </tr>
+                        <tr>
+                            <td class=""table-row"">{{IncompleteRowName}}</td>
+                            <td class=""table-entry""><a href=""#{{IncompleteKey}}"">{{IncompleteCount}}</a></td>
+                        </tr>
+                        <tr>
+                            <td class=""table-row"">{{InapplicableRowName}}</td>
+                            <td class=""table-entry""><a href=""#{{InapplicableKey}}"">{{InapplicableCount}}</a></td>
+                        </tr>
+                    </table>
                 <br />
                 {{#RuleGroups}}
                     {{> RuleGroup}}
@@ -104,7 +154,7 @@ namespace AxeCore.HTMLReporter.Templates
         ";
 
         internal static string RuleGroup = @"
-            <section id=""{{RuleGroupId}}"" class=""violation"">
+            <section id=""{{RuleGroupId}}"" class=""{{RuleGroupId}}"">
                 {{#Rules}}
                     {{> Rule}}
                 {{/Rules}}
@@ -112,10 +162,14 @@ namespace AxeCore.HTMLReporter.Templates
         ";
 
         internal static string Rule = @"
-            <hr class=""rule-divider violation"" />
-            <section id=""{{RuleId}}"">
+            <hr class=""rule-divider {{RuleGroupId}}"" />
+            <section id=""rule {{RuleId}}"">
                 <h2>{{RuleTitle}}</h2>
-                <table class=""violation"">
+                <table class=""rule {{RuleGroupId}}"">
+                    <tr>
+                        <td class=""table-row"">{{RuleOutcomeRowName}}</td>
+                        <td class=""table-entry"">{{RuleOutcome}}</td>
+                    </tr>
                     <tr>
                         <td class=""table-row"">{{ImpactRowName}}</td>
                         <td class=""table-entry"">{{Impact}}</td>


### PR DESCRIPTION

Updated Report styling:

- Colouring based on rule group.
- Using flexbox so content can wrap when images are added in the future.
-
<img width="1897" alt="image" src="https://user-images.githubusercontent.com/36536997/221386432-afcf3281-825e-48cb-861f-8d324a9999c4.png">

<img width="1890" alt="image" src="https://user-images.githubusercontent.com/36536997/221386429-18c3d917-1620-4445-a766-c240f7b99736.png">

- Updated result occurrence in table to summarize based on Nodes.

- Updated Test Server to receive Result option in Url:
e.g. `http://localhost:5137/?testUrl=https://www.google.com&reportRuleTypes=Passes&reportRuleTypes=Violations&reportRuleTypes=Inapplicable&reportRuleTypes=Incomplete`