### PR TITLE
Hiding rule links when 0 or ommitted

### DIFF
--- a/src/html-reporter/AxeHTMLReporter.cs
+++ b/src/html-reporter/AxeHTMLReporter.cs
@@ -19,6 +19,11 @@ namespace AxeCore.HTMLReporter
         /// </summary>
         public static AxeHTMLReporter Instance { get; }
 
+        private static readonly AxeHTMLReportOptions s_defaultOptions = new AxeHTMLReportOptions()
+        {
+            ReportRuleTypes = AxeReportRuleTypes.Violations
+        };
+
         static AxeHTMLReporter()
         {
             Instance = new AxeHTMLReporter();
@@ -41,7 +46,9 @@ namespace AxeCore.HTMLReporter
 
             var template = handlebars.Compile(documentBody);
 
-            ReportViewModel model = CreateReportModel(results, options);
+            AxeHTMLReportOptions mergedOptions = options ?? s_defaultOptions;
+
+            ReportViewModel model = CreateReportModel(results, mergedOptions);
 
             var result = template(model);
 
@@ -65,10 +72,17 @@ namespace AxeCore.HTMLReporter
                 options)
                 .ToArray();
 
+            AxeReportRuleTypes rulesToInclude = options.ReportRuleTypes;
+
             int violationCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Violations);
             int passesCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Passes);
             int incompleteCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Incomplete);
             int inapplicableCount = RuleGroupUtils.GetRuleGroupNodeCount(results.Inapplicable);
+
+            bool showViolationsRulesLink = violationCount > 0 && rulesToInclude.IncludesViolations();
+            bool showPassesRulesLink = passesCount > 0 && rulesToInclude.IncludesPasses();
+            bool showIncompleteRulesLink = incompleteCount > 0 && rulesToInclude.IncludesIncomplete();
+            bool showInapplicableRulesLink = inapplicableCount > 0 && rulesToInclude.IncludesInapplicable();
 
             return new ReportViewModel()
             {
@@ -91,7 +105,11 @@ namespace AxeCore.HTMLReporter
                 InapplicableRowName = Strings.InapplicableRowName,
                 InapplicableKey = ReportContants.InapplicableKey,
                 InapplicableCount = inapplicableCount,
-                RuleGroups = ruleGroups
+                RuleGroups = ruleGroups,
+                ShowViolationsRulesLink = showViolationsRulesLink,
+                ShowPassesRulesLink = showPassesRulesLink,
+                ShowIncompleteRulesLink = showIncompleteRulesLink,
+                ShowInapplicableRulesLink = showInapplicableRulesLink,
             };
         }
     }

--- a/src/html-reporter/AxeReportRuleTypesExtensions.cs
+++ b/src/html-reporter/AxeReportRuleTypesExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter
+{
+    /// <summary>
+    /// Axe Report Rule Types Extensions
+    /// </summary>
+    internal static class AxeReportRuleTypesExtensions
+    {
+        /// <summary>
+        /// Are Violations Included
+        /// </summary>
+        public static bool IncludesViolations(this AxeReportRuleTypes ruleTypes) => ruleTypes.HasFlag(AxeReportRuleTypes.Violations)
+                || ruleTypes.HasFlag(AxeReportRuleTypes.All);
+
+        /// <summary>
+        /// Are Passes Included
+        /// </summary>
+        public static bool IncludesPasses(this AxeReportRuleTypes ruleTypes) => ruleTypes.HasFlag(AxeReportRuleTypes.Passes)
+                || ruleTypes.HasFlag(AxeReportRuleTypes.All);
+
+        /// <summary>
+        /// Are Incomplete Rules Incuded
+        /// </summary>
+        public static bool IncludesIncomplete(this AxeReportRuleTypes ruleTypes) => ruleTypes.HasFlag(AxeReportRuleTypes.Incomplete)
+                || ruleTypes.HasFlag(AxeReportRuleTypes.All);
+
+        /// <summary>
+        /// Are Applicable Rules Included
+        /// </summary>
+        public static bool IncludesInapplicable(this AxeReportRuleTypes ruleTypes) => ruleTypes.HasFlag(AxeReportRuleTypes.Inapplicable)
+                || ruleTypes.HasFlag(AxeReportRuleTypes.All);
+    }
+}

--- a/src/html-reporter/Models/ReportViewModel.cs
+++ b/src/html-reporter/Models/ReportViewModel.cs
@@ -107,5 +107,25 @@ namespace AxeCore.HTMLReporter.Models
         /// Rule Groups
         /// </summary>
         public RuleGroupModel[] RuleGroups { get; set; }
+
+        /// <summary>
+        /// Should the count of the violated rules be shown as a link?
+        /// </summary>
+        public bool ShowViolationsRulesLink { get; set; }
+
+        /// <summary>
+        /// Should the count of the passed rules be shown as a link?
+        /// </summary>
+        public bool ShowPassesRulesLink { get; set; }
+
+        /// <summary>
+        /// Should the count of the inapplicable rules be shown as a link?
+        /// </summary>
+        public bool ShowInapplicableRulesLink { get; set; }
+
+        /// <summary>
+        /// Should the count of the incomplete rules be shown as a link?
+        /// </summary>
+        public bool ShowIncompleteRulesLink { get; set; }
     }
 }

--- a/src/html-reporter/RuleGroupUtils.cs
+++ b/src/html-reporter/RuleGroupUtils.cs
@@ -29,19 +29,19 @@ namespace AxeCore.HTMLReporter
         {
             AxeReportRuleTypes rulesToInclude = options?.ReportRuleTypes ?? AxeReportRuleTypes.Violations;
 
-            if (rulesToInclude.HasFlag(AxeReportRuleTypes.Violations) || rulesToInclude.HasFlag(AxeReportRuleTypes.All))
+            if (rulesToInclude.IncludesViolations())
             {
                 yield return CreateRuleGroup(ReportContants.ViolationsKey, violations, language);
             }
-            if (rulesToInclude.HasFlag(AxeReportRuleTypes.Passes) || rulesToInclude.HasFlag(AxeReportRuleTypes.All))
+            if (rulesToInclude.IncludesPasses())
             {
                 yield return CreateRuleGroup(ReportContants.PassesKey, passes, language);
             }
-            if (rulesToInclude.HasFlag(AxeReportRuleTypes.Inapplicable) || rulesToInclude.HasFlag(AxeReportRuleTypes.All))
+            if (rulesToInclude.IncludesInapplicable())
             {
                 yield return CreateRuleGroup(ReportContants.InapplicableKey, inapplicable, language);
             }
-            if (rulesToInclude.HasFlag(AxeReportRuleTypes.Incomplete) || rulesToInclude.HasFlag(AxeReportRuleTypes.All))
+            if (rulesToInclude.IncludesIncomplete())
             {
                 yield return CreateRuleGroup(ReportContants.IncompleteKey, incomplete, language);
             }

--- a/src/html-reporter/Templates/HtmlTemplates.cs
+++ b/src/html-reporter/Templates/HtmlTemplates.cs
@@ -131,19 +131,43 @@ namespace AxeCore.HTMLReporter.Templates
                         </tr>
                         <tr>
                             <td class=""table-row"">{{ViolationsRowName}}</td>
-                            <td class=""table-entry""><a href=""#{{ViolationsKey}}"">{{ViolationsCount}}</a></td>
+                            <td class=""table-entry"">
+                                {{#if ShowViolationsRulesLink}}
+                                <a href=""#{{ViolationsKey}}"">{{ViolationsCount}}</a>
+                                {{else}}
+                                <span>{{ViolationsCount}}</span>
+                                {{/if}}
+                            </td>
                         </tr>
                         <tr>
                             <td class=""table-row"">{{PassesRowName}}</td>
-                            <td class=""table-entry""><a href=""#{{PassesKey}}"">{{PassesCount}}</a></td>
+                            <td class=""table-entry"">
+                                {{#if ShowPassesRulesLink}}
+                                <a href=""#{{PassesKey}}"">{{PassesCount}}</a>
+                                {{else}}
+                                <span>{{PassesCount}}</span>
+                                {{/if}}
+                            </td>
                         </tr>
                         <tr>
                             <td class=""table-row"">{{IncompleteRowName}}</td>
-                            <td class=""table-entry""><a href=""#{{IncompleteKey}}"">{{IncompleteCount}}</a></td>
+                            <td class=""table-entry"">
+                                {{#if ShowIncompleteRulesLink}}
+                                <a href=""#{{IncompleteKey}}"">{{IncompleteCount}}</a>
+                                {{else}}
+                                <span>{{IncompleteCount}}</span>
+                                {{/if}}
+                            </td>
                         </tr>
                         <tr>
                             <td class=""table-row"">{{InapplicableRowName}}</td>
-                            <td class=""table-entry""><a href=""#{{InapplicableKey}}"">{{InapplicableCount}}</a></td>
+                            <td class=""table-entry"">
+                                {{#if ShowInapplicableRulesLink}}
+                                <a href=""#{{InapplicableKey}}"">{{InapplicableCount}}</a>
+                                {{else}}
+                                <span>{{InapplicableCount}}</span>
+                                {{/if}}
+                            </td>
                         </tr>
                     </table>
                 <br />


### PR DESCRIPTION

Fix for #31 

When there are 0 occurences of a rule type or a rule type is not being displayed, then we don't show the occurrences of that rule type as a link.

http://localhost:5137/?testUrl=https://www.google.com&reportRuleTypes=Passes&reportRuleTypes=Violations
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/36536997/224492137-6d02afe8-dc6d-4507-9f7a-62299507be0f.png">
