### PR TITLE
Added Playwright integration methods and tests

### DIFF
--- a/AxeCore.HtmlReporter.sln
+++ b/AxeCore.HtmlReporter.sln
@@ -19,6 +19,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AxeCore.HTMLReporter.Tests"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AxeCore.HTMLReporter.DevServer", "src\dev-server\AxeCore.HTMLReporter.DevServer.csproj", "{CC2522E5-8DA8-4017-BF55-A520F1E2C1A7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AxeCore.HTMLReporter.Playwright", "src\html-reporter-playwright\AxeCore.HTMLReporter.Playwright.csproj", "{337DD0CB-3FF6-48EB-992F-B6EFCF612DD2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AxeCore.HTMLReporter.Playwright.Tests", "tests\html-reporter-playwright\AxeCore.HTMLReporter.Playwright.Tests.csproj", "{4A50CAB8-E505-444D-9A87-76796F44B1FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +41,14 @@ Global
 		{CC2522E5-8DA8-4017-BF55-A520F1E2C1A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC2522E5-8DA8-4017-BF55-A520F1E2C1A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC2522E5-8DA8-4017-BF55-A520F1E2C1A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{337DD0CB-3FF6-48EB-992F-B6EFCF612DD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{337DD0CB-3FF6-48EB-992F-B6EFCF612DD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{337DD0CB-3FF6-48EB-992F-B6EFCF612DD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{337DD0CB-3FF6-48EB-992F-B6EFCF612DD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A50CAB8-E505-444D-9A87-76796F44B1FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A50CAB8-E505-444D-9A87-76796F44B1FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A50CAB8-E505-444D-9A87-76796F44B1FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A50CAB8-E505-444D-9A87-76796F44B1FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
 	<PackageVersion Include="Handlebars.Net" Version="2.1.2" />
 	<PackageVersion Include="Microsoft.Playwright" Version="1.20.2" />
+	<PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.20.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/src/html-reporter-playwright/AxeCore.HTMLReporter.Playwright.csproj
+++ b/src/html-reporter-playwright/AxeCore.HTMLReporter.Playwright.csproj
@@ -17,4 +17,8 @@
 	<PackageReference Include="Deque.AxeCore.Commons" />
 	<PackageReference Include="Deque.AxeCore.Playwright" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\html-reporter\AxeCore.HTMLReporter.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/html-reporter-playwright/Extensions.cs
+++ b/src/html-reporter-playwright/Extensions.cs
@@ -3,7 +3,6 @@
 
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Playwright;
-using HandlebarsDotNet;
 using Microsoft.Playwright;
 using System.Threading.Tasks;
 

--- a/src/html-reporter-playwright/Extensions.cs
+++ b/src/html-reporter-playwright/Extensions.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Deque.AxeCore.Commons;
+using Deque.AxeCore.Playwright;
+using HandlebarsDotNet;
+using Microsoft.Playwright;
+using System.Threading.Tasks;
+
+namespace AxeCore.HTMLReporter.Playwright
+{
+    /// <summary>
+    /// Page Extensions which add HTML Report Options
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Runs Axe against the page in its current state.
+        /// </summary>
+        /// <param name="page">The Playwright Page object</param>
+        /// <param name="options">Options for running Axe.</param>
+        /// <param name="htmlReportOptions">HTML report options.</param>
+        /// <returns>The AxeResult</returns>
+        public static async Task<AxeResult> RunAxe(
+            this IPage page,
+            AxeRunOptions options,
+            PlaywrightAxeHtmlReportOptions htmlReportOptions)
+            => await RunAxeInner(page, null, options, null, htmlReportOptions);
+
+        /// <summary>
+        /// Runs Axe against the page in its current state.
+        /// </summary>
+        /// <param name="page">The Playwright Page object</param>
+        /// <param name="context">Context to specify which element to run axe on.</param>
+        /// <param name="options">Options for running Axe.</param>
+        /// <param name="htmlReportOptions">HTML report options.</param>
+        /// <returns>The AxeResult</returns>
+        public static async Task<AxeResult> RunAxe(
+            this IPage page,
+            AxeRunContext context,
+            AxeRunOptions options,
+            string axeSource,
+            PlaywrightAxeHtmlReportOptions htmlReportOptions)
+            => await RunAxeInner(page, context, options, axeSource, htmlReportOptions);
+
+        public static async Task<AxeResult> RunAxe(
+            this ILocator locator,
+            AxeRunOptions options,
+            PlaywrightAxeHtmlReportOptions htmlReportOptions)
+        {
+            AxeResult results = await locator.RunAxe(options);
+            CreateReportAndWriteFile(results, htmlReportOptions);
+
+            return results;
+        }
+
+        private static async Task<AxeResult> RunAxeInner(
+            IPage page,
+            AxeRunContext context,
+            AxeRunOptions runOptions,
+            string axeSource,
+            PlaywrightAxeHtmlReportOptions htmlReportOptions)
+        {
+            AxeResult results = await page.RunAxe(context, runOptions, axeSource);
+            CreateReportAndWriteFile(results, htmlReportOptions);
+
+            return results;
+        }
+
+        private static void CreateReportAndWriteFile(AxeResult results, PlaywrightAxeHtmlReportOptions htmlReportOptions)
+        {
+            IAxeHTMLReporter reporter = AxeHTMLReporter.Instance;
+            AxeHTMLReport report = reporter.CreateReport(results, htmlReportOptions);
+
+            report.WriteToFile(htmlReportOptions.ReportFilename);
+        }
+    }
+}

--- a/src/html-reporter-playwright/PlaywrightAxeHtmlReportOptions.cs
+++ b/src/html-reporter-playwright/PlaywrightAxeHtmlReportOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter.Playwright
+{
+    /// <inheritdoc />
+    public sealed class PlaywrightAxeHtmlReportOptions : AxeHTMLReportOptions
+    {
+        /// <summary>
+        /// Report Filename
+        /// </summary>
+        public string ReportFilename { get; set; } = null;
+    }
+}

--- a/src/html-reporter/AxeHTMLReportOptions.cs
+++ b/src/html-reporter/AxeHTMLReportOptions.cs
@@ -6,7 +6,7 @@ namespace AxeCore.HTMLReporter
     /// <summary>
     /// Options for configuring the HTML report.
     /// </summary>
-    public sealed class AxeHTMLReportOptions
+    public class AxeHTMLReportOptions
     {
         /// <summary>
         /// Specifies which rule types to include in the report.

--- a/src/html-reporter/RuleGroupUtils.cs
+++ b/src/html-reporter/RuleGroupUtils.cs
@@ -54,7 +54,7 @@ namespace AxeCore.HTMLReporter
         /// </summary>
         public static int GetRuleGroupNodeCount(AxeResultItem[] results)
         {
-            return results.Sum(result => result.Nodes?.Length ?? 0);
+            return results?.Sum(result => result.Nodes?.Length ?? 0) ?? 0;
         }
 
         private static RuleGroupModel CreateRuleGroup(string ruleGroupId, AxeResultItem[] itemResults, CultureInfo locale)

--- a/tests/html-reporter-playwright/AxeCore.HTMLReporter.Playwright.Tests.csproj
+++ b/tests/html-reporter-playwright/AxeCore.HTMLReporter.Playwright.Tests.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="TestData\default-test-page.html" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -12,9 +15,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\html-reporter\AxeCore.HTMLReporter.Playwright.csproj" />
 	<PackageReference Include="Microsoft.Playwright" />
+	<PackageReference Include="Microsoft.Playwright.NUnit" />
 	<PackageReference Include="Deque.AxeCore.Commons" />
 	<PackageReference Include="Deque.AxeCore.Playwright" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="TestData\default-test-page.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\html-reporter-playwright\AxeCore.HTMLReporter.Playwright.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/html-reporter-playwright/IntegrationTests.cs
+++ b/tests/html-reporter-playwright/IntegrationTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Playwright.NUnit;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Deque.AxeCore.Commons;
+using System.Collections.Generic;
+using Microsoft.Playwright;
+
+namespace AxeCore.HTMLReporter.Playwright.Tests
+{
+    [TestFixture]
+    [Category("Integration")]
+    public sealed class IntegrationTests : PageTest
+    {
+        [Test]
+        public async Task RunAxe_DefaultOverride_ShouldCreateHTMLReport()
+        {
+            string reportFilename = GetTestFileName();
+
+            await NavigateToTestPage();
+
+            PlaywrightAxeHtmlReportOptions htmlReportOptions = new()
+            {
+                ReportFilename = reportFilename,
+            };
+
+            await Page.RunAxe(null, htmlReportOptions: htmlReportOptions);
+
+            FileAssert.Exists(reportFilename);
+        }
+
+        [Test]
+        public async Task RunAxe_WithContextOverride_ShouldCreateHTMLReport()
+        {
+            string reportFilename = GetTestFileName();
+
+            await NavigateToTestPage();
+
+            PlaywrightAxeHtmlReportOptions htmlReportOptions = new()
+            {
+                ReportFilename = reportFilename,
+            };
+
+            AxeRunContext context = new()
+            {
+                Exclude = new List<AxeSelector>
+                {
+                    new AxeSelector("a")
+                }
+            };
+
+            await Page.RunAxe(context, null, null, htmlReportOptions: htmlReportOptions);
+
+            FileAssert.Exists(reportFilename);
+        }
+
+        [Test]
+        public async Task RunAxe_LocatorOverride_ShouldCreateHTMLReport()
+        {
+            string reportFilename = GetTestFileName();
+
+            await NavigateToTestPage();
+
+            PlaywrightAxeHtmlReportOptions htmlReportOptions = new()
+            {
+                ReportFilename = reportFilename,
+            };
+
+            ILocator formLocator = Page.Locator("form");
+            await formLocator.RunAxe(null, htmlReportOptions);
+
+            FileAssert.Exists(reportFilename);
+        }
+
+        /// <summary>
+        /// Rather than running a development server for the tests we will use a file protocol and local test files.
+        /// </summary>
+        private async Task NavigateToTestPage(string file = "default-test-page.html")
+        {
+            string fullFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", file);
+
+            if (!File.Exists(fullFilePath))
+            {
+                throw new FileNotFoundException($"File not found at {fullFilePath}");
+            }
+
+            Uri uri = new($"file://{fullFilePath}");
+
+            await Page.GotoAsync(uri.ToString());
+        }
+
+        private static string GetTestFileName()
+        {
+            return string.Join("-", TestContext.CurrentContext.Random.NextGuid(), TestContext.CurrentContext.Test.MethodName, "Report.html");
+        }
+    }
+}

--- a/tests/html-reporter-playwright/TestData/default-test-page.html
+++ b/tests/html-reporter-playwright/TestData/default-test-page.html
@@ -1,0 +1,19 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Default Test Page</title>
+</head>
+<body>
+    <form action="/form-without-label">
+        <select id="options" name="options">
+            <option value="option-one">Option 1</option>
+            <option value="option-two">Option 2</option>
+            <option value="option-three">Option 3</option>
+            <option value="option-four">Option 4</option>
+        </select>
+        <input type="submit">
+    </form>
+</body>
+</html>


### PR DESCRIPTION

Adding the Playwright-specific integration methods and tests.

The approach is to add overrides for the existing Page and Locator extensions so that creating the report is more natural with the existing method of running Axe with Playwright.

The class for specifying options is specific for each integration as there may be certain functionalities that will be unachievable with a particular library (e.g. taking snapshot images).