### PR TITLE
Added Image Context interface to reporter interface

### DIFF
--- a/src/html-reporter/IAxeHTMLReporter.cs
+++ b/src/html-reporter/IAxeHTMLReporter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AxeCore.HTMLReporter.Image;
 using Deque.AxeCore.Commons;
 
 namespace AxeCore.HTMLReporter
@@ -15,7 +16,8 @@ namespace AxeCore.HTMLReporter
         /// </summary>
         /// <param name="results">The axe-core results.</param>
         /// <param name="options">HTML Report options.</param>
+        /// <param name="imageContext">Context for images being displayed in the report.</param>
         /// <returns>The HTML report object.</returns>
-        AxeHTMLReport CreateReport(AxeResult results, AxeHTMLReportOptions options = null);
+        AxeHTMLReport CreateReport(AxeResult results, AxeHTMLReportOptions options = null, AxeHTMLReportImageContext imageContext = null);
     }
 }

--- a/src/html-reporter/Image/AxeHTMLReportImageContext.cs
+++ b/src/html-reporter/Image/AxeHTMLReportImageContext.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter.Image
+{
+    /// <summary>
+    /// The information related to include and display images in the HTML Report.
+    /// </summary>
+    public sealed class AxeHTMLReportImageContext
+    {
+        /// <summary>
+        /// Source Image of the page.
+        /// </summary>
+        public ReportImage SourceImage { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="sourceImage">Source Image of the page.</param>
+        public AxeHTMLReportImageContext(ReportImage sourceImage)
+        {
+            SourceImage = sourceImage;
+        }
+    }
+}

--- a/src/html-reporter/Image/ReportImage.cs
+++ b/src/html-reporter/Image/ReportImage.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AxeCore.HTMLReporter.Image
+{
+    /// <summary>
+    /// Image which can be embedded in the HTML Report
+    /// </summary>
+    public sealed class ReportImage
+    {
+        /// <summary>
+        /// Image Buffer Data
+        /// </summary>
+        public byte[] Bytes { get; }
+
+        /// <summary>
+        /// Format
+        /// </summary>
+        public ImageFormat Format { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="bytes">Image Buffer Data</param>
+        /// <param name="format">Format</param>
+        public ReportImage(byte[] bytes, ImageFormat format)
+        {
+            Bytes = bytes;
+            Format = format;
+        }
+    }
+}

--- a/src/html-reporter/Models/ReportViewModel.cs
+++ b/src/html-reporter/Models/ReportViewModel.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace AxeCore.HTMLReporter.Models
 {
     /// <summary>
@@ -102,6 +104,11 @@ namespace AxeCore.HTMLReporter.Models
         /// Inapplicable Count
         /// </summary>
         public int InapplicableCount { get; set; }
+
+        /// <summary>
+        /// Source Image
+        /// </summary>
+        public Uri SourceImage { get; set; }
 
         /// <summary>
         /// Rule Groups

--- a/tests/html-reporter/AxeHTMLReporterTests.cs
+++ b/tests/html-reporter/AxeHTMLReporterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using AxeCore.HTMLReporter.Image;
 using NUnit.Framework;
 
 namespace AxeCore.HTMLReporter.Tests
@@ -14,6 +15,21 @@ namespace AxeCore.HTMLReporter.Tests
             AxeHTMLReporter reporter = AxeHTMLReporter.Instance;
 
             AxeHTMLReport report = reporter.CreateReport(TestData.CreateDefaultResult());
+
+            Assert.IsNotNull(report);
+            Assert.IsNotEmpty(report.ToString());
+        }
+
+        [Test]
+        public void CreateReport_WithImageContext_ReportShouldNotBeNullOrEmpty()
+        {
+            AxeHTMLReporter reporter = AxeHTMLReporter.Instance;
+
+            ReportImage reportImage = new ReportImage(new byte[] { 1, 1, 1, 1 }, ImageFormat.JPeg);
+
+            AxeHTMLReportImageContext imageContext = new AxeHTMLReportImageContext(reportImage);
+
+            AxeHTMLReport report = reporter.CreateReport(TestData.CreateDefaultResult(), null, imageContext);
 
             Assert.IsNotNull(report);
             Assert.IsNotEmpty(report.ToString());


### PR DESCRIPTION
This PR adds the interface to the basic reporter to support images.

The functionality of displaying images in the report is activated by included an `AxeHTMLReportImageContext` object.  This will contain everything that the report needs to display images. Presently, this will just be a source image: which is a full screenshot of the system-under-test. This will eventually be expanded to include element screenshots.
